### PR TITLE
add missing options to dervie.mnemonic method

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Options:
 
 - **passphrase**  
   Default: (none), alternatively: 'my secret passsword'
+- **accountPath**  
+  Default: (0), alternatively: any integer
+- **changePath**  
+  Default: (0), alternatively: any integer
+- **addressIndex**  
+  Default: (0), alternatively: any integer
 
 ### Passphrase `lib.derive.passphrase(passphrase'')`
 


### PR DESCRIPTION
Adds the following missing options in the doc for `derive.mnemonic`:

- accountPath  
- changePath
- addressIndex 